### PR TITLE
feat: add /whats-next staging area with themed marquee

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -47,6 +47,7 @@ const AdminReviewsPage = React.lazy(() => import("@/pages/admin/reviews"));
 const PasswordChangePage = React.lazy(() => import("@/pages/admin/password"));
 const DatabaseExportPage = React.lazy(() => import("@/pages/admin/database-export"));
 const ArticlePage = React.lazy(() => import("@/pages/admin/Article"));
+const WhatsNextPage = React.lazy(() => import("@/pages/whats-next"));
 
 function RouteFallback() {
   return <div>Loading...</div>;
@@ -127,6 +128,7 @@ function Router() {
   return (
     <Switch>
       <Route path="/" component={HomePage} />
+      <Route path="/whats-next">{() => <SuspendedRoute><WhatsNextPage /></SuspendedRoute>}</Route>
       <Route path="/tours">{() => <SuspendedRoute><ToursPage /></SuspendedRoute>}</Route>
       <Route path="/gallery">{() => <SuspendedRoute><GalleryPage /></SuspendedRoute>}</Route>
       <Route path="/3-day-guide-book">{() => <SuspendedRoute><GuidePage /></SuspendedRoute>}</Route>

--- a/client/src/pages/whats-next/Marquee.tsx
+++ b/client/src/pages/whats-next/Marquee.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from "react-i18next";
+
+const FALLBACK_ITEMS_EN = [
+  "Lisbon Tours",
+  "Local Guides",
+  "Alfama",
+  "Belém",
+  "Fado Nights",
+  "Tagus River",
+  "Pastéis de Nata",
+  "Hidden Gems",
+];
+
+const FALLBACK_ITEMS_PT = [
+  "Tours em Lisboa",
+  "Guias Locais",
+  "Alfama",
+  "Belém",
+  "Noites de Fado",
+  "Rio Tejo",
+  "Pastéis de Nata",
+  "Tesouros Escondidos",
+];
+
+export default function Marquee() {
+  const { i18n } = useTranslation();
+  const items = i18n.language?.startsWith("pt") ? FALLBACK_ITEMS_PT : FALLBACK_ITEMS_EN;
+  // Duplicate the list so the -50% translateX loop is seamless.
+  const loop = [...items, ...items];
+
+  return (
+    <div className="wn-marquee-wrap" aria-hidden="true">
+      <div className="wn-marquee-track">
+        {loop.map((label, i) => (
+          <span className="wn-marquee-item" key={`${label}-${i}`}>
+            {label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/whats-next/index.tsx
+++ b/client/src/pages/whats-next/index.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import HeroSection from "@/pages/home/HeroSection";
+import FeaturedTours from "@/pages/home/FeaturedTours";
+import AboutUs from "@/pages/home/AboutUs";
+import WhyChooseUs from "@/pages/home/WhyChooseUs";
+import Reviews from "@/pages/home/Reviews";
+import PhotoGallery from "@/pages/home/PhotoGallery";
+import CallToAction from "@/pages/home/CallToAction";
+import ContactInformation from "@/pages/home/ContactInformation";
+import Marquee from "./Marquee";
+import "./theme.css";
+
+/**
+ * "What's Next" — staging area for the site.
+ * New features and visual changes land here first, then graduate to production.
+ */
+export default function WhatsNextPage() {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  return (
+    <div className="wn-theme">
+      <div className="wn-staging-banner">
+        What&apos;s Next · Staging Preview
+      </div>
+      <Marquee />
+      <HeroSection />
+      <FeaturedTours />
+      <AboutUs />
+      <WhyChooseUs />
+      <Reviews />
+      <PhotoGallery />
+      <CallToAction />
+      <ContactInformation />
+    </div>
+  );
+}

--- a/client/src/pages/whats-next/theme.css
+++ b/client/src/pages/whats-next/theme.css
@@ -1,0 +1,77 @@
+/* Scoped theme for the /whats-next staging area.
+   Tokens come from the Forma Studio reference design. */
+
+@import url('https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:wght@300;400;500&display=swap');
+
+.wn-theme {
+  --wn-bg: #F2EDE6;
+  --wn-dark: #181512;
+  --wn-accent: #E8522A;
+  --wn-mid: #7A6F67;
+  --wn-light: #E2DCD4;
+  --wn-white: #FAF8F5;
+  --wn-border: rgba(24, 21, 18, 0.1);
+
+  background: var(--wn-bg);
+  color: var(--wn-dark);
+  font-family: 'DM Sans', sans-serif;
+  font-weight: 300;
+}
+
+.wn-theme h1,
+.wn-theme h2,
+.wn-theme h3,
+.wn-theme .wn-serif {
+  font-family: 'DM Serif Display', serif;
+}
+
+.wn-theme em {
+  color: var(--wn-accent);
+  font-style: italic;
+}
+
+/* Marquee */
+.wn-marquee-wrap {
+  overflow: hidden;
+  padding: 0.9rem 0;
+  background: var(--wn-dark);
+}
+
+.wn-marquee-track {
+  display: flex;
+  gap: 3rem;
+  animation: wn-marquee 22s linear infinite;
+  width: max-content;
+}
+
+.wn-marquee-item {
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(250, 248, 245, 0.38);
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 3rem;
+}
+
+.wn-marquee-item::after {
+  content: '✦';
+  color: var(--wn-accent);
+  font-size: 0.55rem;
+}
+
+@keyframes wn-marquee {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+
+.wn-staging-banner {
+  background: var(--wn-accent);
+  color: var(--wn-white);
+  text-align: center;
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  padding: 0.5rem 1rem;
+}


### PR DESCRIPTION
Introduces a parallel staging route where new visual changes can land before being promoted to production. Initial scope: a Forma-inspired theme (scoped under .wn-theme so prod is untouched) and a moving marquee strip on the staging home page.