### PR TITLE
feat: /whats-next staging area with Forma-themed home

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -53,6 +53,31 @@ function RouteFallback() {
   return <div>Loading...</div>;
 }
 
+function LayoutShell() {
+  const [location] = useLocation();
+  const isWhatsNext = location.startsWith("/whats-next");
+
+  if (isWhatsNext) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <main className="flex-grow">
+          <Router />
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <NavBar />
+      <main className="flex-grow" style={{ paddingTop: "var(--navbar-height, 56px)" }}>
+        <Router />
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
 function SuspendedRoute({ children }: { children: React.ReactNode }) {
   return <React.Suspense fallback={<RouteFallback />}>{children}</React.Suspense>;
 }
@@ -329,13 +354,7 @@ function LanguageAwareApp() {
     <WouterRouter hook={useLocalizedBrowserLocation} hrefs={formatLocalizedHref}>
       <LanguagePathSync />
       <TooltipProvider>
-        <div className="min-h-screen flex flex-col">
-          <NavBar />
-          <main className="flex-grow" style={{ paddingTop: 'var(--navbar-height, 56px)' }}>
-            <Router />
-          </main>
-          <Footer />
-        </div>
+        <LayoutShell />
         <Toaster />
         <LanguagePreferenceModal
           isOpen={isLanguageModalOpen}

--- a/client/src/pages/whats-next/index.tsx
+++ b/client/src/pages/whats-next/index.tsx
@@ -1,22 +1,320 @@
 import { useEffect } from "react";
-import HeroSection from "@/pages/home/HeroSection";
-import FeaturedTours from "@/pages/home/FeaturedTours";
-import AboutUs from "@/pages/home/AboutUs";
-import WhyChooseUs from "@/pages/home/WhyChooseUs";
-import Reviews from "@/pages/home/Reviews";
-import PhotoGallery from "@/pages/home/PhotoGallery";
-import CallToAction from "@/pages/home/CallToAction";
-import ContactInformation from "@/pages/home/ContactInformation";
+import { Link } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { useTours, useTestimonials } from "@/hooks/use-tours";
+import type { Tour, Testimonial } from "@shared/schema";
 import Marquee from "./Marquee";
 import "./theme.css";
 
-/**
- * "What's Next" — staging area for the site.
- * New features and visual changes land here first, then graduate to production.
- */
+const DEFAULT_HERO =
+  "https://images.unsplash.com/photo-1558370781-d6196949e317?ixlib=rb-4.0.3&auto=format&fit=crop&w=1920&h=1200";
+
+type Lang = "en" | "pt" | "ru";
+
+function pickLang(value: { en: string; pt: string; ru: string } | undefined, lang: Lang): string {
+  if (!value) return "";
+  return value[lang] || value.en || "";
+}
+
+function useLang(): Lang {
+  const { i18n } = useTranslation();
+  const code = (i18n.language || "en").slice(0, 2).toLowerCase();
+  if (code === "pt" || code === "ru") return code;
+  return "en";
+}
+
+/* ───────── Nav ───────── */
+function WhatsNextNav() {
+  const { i18n } = useTranslation();
+  const lang = useLang();
+  return (
+    <nav className="wn-nav">
+      <Link href="/whats-next" className="wn-logo">
+        Lisbonlovesme<span>.</span>
+      </Link>
+      <ul className="wn-nav-links">
+        <li><a href="#tours">{lang === "pt" ? "Tours" : "Tours"}</a></li>
+        <li><a href="#about">{lang === "pt" ? "Sobre" : "About"}</a></li>
+        <li><a href="#reviews">{lang === "pt" ? "Avaliações" : "Reviews"}</a></li>
+        <li><a href="#contact">{lang === "pt" ? "Contacto" : "Contact"}</a></li>
+      </ul>
+      <div className="wn-nav-right">
+        <div className="wn-lang-toggle">
+          <button
+            className={lang === "en" ? "active" : ""}
+            onClick={() => i18n.changeLanguage("en")}
+          >EN</button>
+          <button
+            className={lang === "pt" ? "active" : ""}
+            onClick={() => i18n.changeLanguage("pt")}
+          >PT</button>
+        </div>
+        <Link href="/" className="wn-btn-accent">
+          {lang === "pt" ? "Voltar ao site" : "Back to live site"}
+        </Link>
+      </div>
+    </nav>
+  );
+}
+
+/* ───────── Hero ───────── */
+function WhatsNextHero() {
+  const lang = useLang();
+  const { data: adminSettings } = useQuery<{ heroBannerImageUrl?: string }>({
+    queryKey: ["/api/settings"],
+    queryFn: () => fetch("/api/settings").then((r) => r.json()),
+  });
+  const bg = adminSettings?.heroBannerImageUrl || DEFAULT_HERO;
+
+  return (
+    <section className="wn-hero">
+      <div className="wn-hero-bg" style={{ backgroundImage: `url('${bg}')` }} />
+      <div className="wn-hero-inner">
+        <div style={{ position: "relative", zIndex: 1 }}>
+          <p className="wn-tag">
+            {lang === "pt" ? "Tours autênticos · Lisboa" : "Authentic tours · Lisbon"}
+          </p>
+          <h1 className="wn-hero-h1">
+            {lang === "pt" ? (
+              <>Descubra Lisboa<br /><em>como um local</em></>
+            ) : (
+              <>Discover Lisbon<br /><em>like a local</em></>
+            )}
+          </h1>
+        </div>
+        <div className="wn-hero-right" style={{ position: "relative", zIndex: 1 }}>
+          <p className="wn-hero-desc">
+            {lang === "pt"
+              ? "Tours guiados por moradores apaixonados, com histórias, sabores e cantos escondidos que só Lisboa pode oferecer."
+              : "Walking tours led by locals who love this city — stories, flavours and hidden corners only Lisbon can offer."}
+          </p>
+          <div className="wn-hero-actions">
+            <a href="#tours" className="wn-btn">
+              {lang === "pt" ? "Ver tours" : "View tours"}
+            </a>
+            <a href="#contact" className="wn-btn-outline">
+              {lang === "pt" ? "Fale connosco" : "Get in touch"}
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ───────── Stats ───────── */
+function WhatsNextStats() {
+  const lang = useLang();
+  const stats: Array<[string, string]> = lang === "pt"
+    ? [["2500+", "Visitantes guiados"], ["10+", "Anos em Lisboa"], ["4.9★", "Avaliação média"], ["12", "Bairros explorados"]]
+    : [["2500+", "Travellers guided"], ["10+", "Years in Lisbon"], ["4.9★", "Average rating"], ["12", "Neighbourhoods covered"]];
+  return (
+    <div className="wn-stats">
+      {stats.map(([n, l]) => (
+        <div className="wn-stat" key={l}>
+          <div className="wn-stat-n">{n}</div>
+          <div className="wn-stat-l">{l}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ───────── Services strip ───────── */
+function WhatsNextServices() {
+  const lang = useLang();
+  const items = lang === "pt"
+    ? [
+        ["01", "Tours a pé", "Caminhadas guiadas pelos bairros mais autênticos da cidade."],
+        ["02", "Gastronomia", "Pastéis, vinhos e petiscos com paragens em locais favoritos dos lisboetas."],
+        ["03", "Cultura & Fado", "Música, história e tradições — vividas, não apenas contadas."],
+        ["04", "Tours privados", "Experiências personalizadas para famílias, casais e grupos pequenos."],
+      ]
+    : [
+        ["01", "Walking tours", "Guided walks through Lisbon's most authentic neighbourhoods."],
+        ["02", "Food & wine", "Pastéis, wines and tascas at the spots locals actually love."],
+        ["03", "Culture & Fado", "Music, history and traditions — lived, not just told."],
+        ["04", "Private tours", "Tailored experiences for families, couples and small groups."],
+      ];
+
+  return (
+    <div className="wn-services">
+      {items.map(([num, name, desc]) => (
+        <div className="wn-service" key={num}>
+          <div className="wn-service-num">{num}</div>
+          <div className="wn-service-name">{name}</div>
+          <div className="wn-service-desc">{desc}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ───────── Featured tours ───────── */
+function WhatsNextFeatured() {
+  const lang = useLang();
+  const { tours, isLoading } = useTours();
+  const visible = (tours as Tour[]).slice(0, 3);
+
+  return (
+    <section id="tours" className="wn-featured">
+      <div className="wn-section-head">
+        <h2 className="wn-section-title">
+          {lang === "pt" ? <>Tours <em>selecionados</em></> : <>Selected <em>tours</em></>}
+        </h2>
+        <Link href="/tours" className="wn-see-all">
+          {lang === "pt" ? "Ver todos →" : "View all →"}
+        </Link>
+      </div>
+      <div className="wn-work-grid">
+        {isLoading && visible.length === 0 && (
+          <>
+            <div className="wn-work-card"><div className="wn-work-img" /><div className="wn-work-info"><div className="wn-work-tag">…</div><div className="wn-work-title">Loading</div></div></div>
+            <div className="wn-work-card"><div className="wn-work-img" /><div className="wn-work-info"><div className="wn-work-tag">…</div><div className="wn-work-title">Loading</div></div></div>
+            <div className="wn-work-card"><div className="wn-work-img" /><div className="wn-work-info"><div className="wn-work-tag">…</div><div className="wn-work-title">Loading</div></div></div>
+          </>
+        )}
+        {visible.map((tour) => (
+          <Link
+            key={tour.id}
+            href={`/tour/${tour.id}`}
+            className="wn-work-card"
+          >
+            <div
+              className="wn-work-img"
+              style={tour.imageUrl ? { backgroundImage: `url('${tour.imageUrl}')` } : undefined}
+            />
+            <div className="wn-work-info">
+              <div className="wn-work-tag">
+                {tour.duration} {tour.duration === 1 ? (lang === "pt" ? "hora" : "hour") : (lang === "pt" ? "horas" : "hours")}
+              </div>
+              <div className="wn-work-title">{pickLang(tour.name as any, lang)}</div>
+              <div className="wn-work-meta">€{tour.price / 100} · {pickLang(tour.shortDescription as any, lang).slice(0, 60)}</div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/* ───────── Testimonials ───────── */
+function WhatsNextReviews() {
+  const lang = useLang();
+  const { testimonials } = useTestimonials();
+  const visible = (testimonials as Testimonial[]).slice(0, 3);
+
+  return (
+    <section id="reviews" className="wn-testimonials">
+      <h2 className="wn-section-title">
+        {lang === "pt" ? <><em>O que dizem</em><br />os nossos viajantes</> : <><em>What travellers</em><br />say about us</>}
+      </h2>
+      <div className="wn-testi-grid">
+        {visible.map((t, i) => (
+          <div className="wn-testi-card" key={i}>
+            <div className="wn-testi-stars">
+              {"★".repeat(Math.max(0, Math.min(5, t.rating || 5)))}
+            </div>
+            <p className="wn-testi-quote">"{t.text}"</p>
+            <div className="wn-testi-author">
+              <div className="wn-testi-avatar">{t.customerName?.charAt(0) || "·"}</div>
+              <div>
+                <div className="wn-testi-name">{t.customerName}</div>
+                <div className="wn-testi-role">{t.customerCountry}</div>
+              </div>
+            </div>
+          </div>
+        ))}
+        {visible.length === 0 && (
+          <div className="wn-testi-card">
+            <p className="wn-testi-quote">
+              {lang === "pt"
+                ? "As avaliações dos nossos viajantes vão aparecer aqui."
+                : "Traveller reviews will appear here."}
+            </p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/* ───────── CTA ───────── */
+function WhatsNextCTA() {
+  const lang = useLang();
+  return (
+    <div id="contact" className="wn-cta">
+      <h2>
+        {lang === "pt" ? <>Pronto para descobrir <em>Lisboa</em>?</> : <>Ready to discover <em>Lisbon</em>?</>}
+      </h2>
+      <Link href="/tours" className="wn-btn">
+        {lang === "pt" ? "Reservar um tour →" : "Book a tour →"}
+      </Link>
+    </div>
+  );
+}
+
+/* ───────── Footer ───────── */
+function WhatsNextFooter() {
+  const lang = useLang();
+  return (
+    <footer className="wn-footer">
+      <div className="wn-footer-top">
+        <div>
+          <div className="wn-footer-logo">Lisbonlovesme<span>.</span></div>
+          <p className="wn-footer-tag">
+            {lang === "pt"
+              ? "Tours autênticos por quem ama Lisboa."
+              : "Authentic tours by people who love Lisbon."}
+          </p>
+        </div>
+        <div>
+          <div className="wn-footer-col-title">{lang === "pt" ? "Explorar" : "Explore"}</div>
+          <ul className="wn-footer-links">
+            <li><Link href="/tours">{lang === "pt" ? "Tours" : "Tours"}</Link></li>
+            <li><Link href="/gallery">{lang === "pt" ? "Galeria" : "Gallery"}</Link></li>
+            <li><Link href="/3-day-guide-book">{lang === "pt" ? "Guia 3 dias" : "3-day guide"}</Link></li>
+          </ul>
+        </div>
+        <div>
+          <div className="wn-footer-col-title">{lang === "pt" ? "Contacto" : "Contact"}</div>
+          <ul className="wn-footer-links">
+            <li><a href="mailto:hello@lisbonlovesme.com">hello@lisbonlovesme.com</a></li>
+          </ul>
+        </div>
+        <div>
+          <div className="wn-footer-col-title">{lang === "pt" ? "Conectar" : "Connect"}</div>
+          <ul className="wn-footer-links">
+            <li><a href="#">Instagram</a></li>
+            <li><a href="#">Facebook</a></li>
+          </ul>
+        </div>
+      </div>
+      <div className="wn-footer-bottom">
+        <span className="wn-footer-copy">© {new Date().getFullYear()} Lisbonlovesme.</span>
+        <span className="wn-footer-copy">
+          {lang === "pt" ? "Feito com carinho em Lisboa." : "Made with love in Lisbon."}
+        </span>
+      </div>
+    </footer>
+  );
+}
+
+/* ───────── Page ───────── */
 export default function WhatsNextPage() {
   useEffect(() => {
     window.scrollTo(0, 0);
+    const obs = new IntersectionObserver((entries) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting) {
+          e.target.classList.add("wn-visible");
+          obs.unobserve(e.target);
+        }
+      });
+    }, { threshold: 0.1 });
+    document.querySelectorAll(".wn-theme [data-wn-reveal]").forEach((el) => obs.observe(el));
+    return () => obs.disconnect();
   }, []);
 
   return (
@@ -24,15 +322,15 @@ export default function WhatsNextPage() {
       <div className="wn-staging-banner">
         What&apos;s Next · Staging Preview
       </div>
+      <WhatsNextNav />
+      <WhatsNextHero />
+      <WhatsNextStats />
       <Marquee />
-      <HeroSection />
-      <FeaturedTours />
-      <AboutUs />
-      <WhyChooseUs />
-      <Reviews />
-      <PhotoGallery />
-      <CallToAction />
-      <ContactInformation />
+      <WhatsNextServices />
+      <WhatsNextFeatured />
+      <WhatsNextReviews />
+      <WhatsNextCTA />
+      <WhatsNextFooter />
     </div>
   );
 }

--- a/client/src/pages/whats-next/index.tsx
+++ b/client/src/pages/whats-next/index.tsx
@@ -324,7 +324,6 @@ export default function WhatsNextPage() {
       </div>
       <WhatsNextNav />
       <WhatsNextHero />
-      <WhatsNextStats />
       <Marquee />
       <WhatsNextServices />
       <WhatsNextFeatured />

--- a/client/src/pages/whats-next/theme.css
+++ b/client/src/pages/whats-next/theme.css
@@ -1,5 +1,5 @@
-/* Scoped theme for the /whats-next staging area.
-   Tokens come from the Forma Studio reference design. */
+/* Forma-inspired theme for the /whats-next staging area.
+   All rules are scoped under .wn-theme so production CSS is untouched. */
 
 @import url('https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:wght@300;400;500&display=swap');
 
@@ -7,6 +7,7 @@
   --wn-bg: #F2EDE6;
   --wn-dark: #181512;
   --wn-accent: #E8522A;
+  --wn-accent-dark: #cc3f19;
   --wn-mid: #7A6F67;
   --wn-light: #E2DCD4;
   --wn-white: #FAF8F5;
@@ -16,56 +17,26 @@
   color: var(--wn-dark);
   font-family: 'DM Sans', sans-serif;
   font-weight: 300;
+  min-height: 100vh;
+  overflow-x: hidden;
 }
 
-.wn-theme h1,
-.wn-theme h2,
-.wn-theme h3,
-.wn-theme .wn-serif {
-  font-family: 'DM Serif Display', serif;
+.wn-theme *,
+.wn-theme *::before,
+.wn-theme *::after {
+  box-sizing: border-box;
 }
 
 .wn-theme em {
-  color: var(--wn-accent);
   font-style: italic;
-}
-
-/* Marquee */
-.wn-marquee-wrap {
-  overflow: hidden;
-  padding: 0.9rem 0;
-  background: var(--wn-dark);
-}
-
-.wn-marquee-track {
-  display: flex;
-  gap: 3rem;
-  animation: wn-marquee 22s linear infinite;
-  width: max-content;
-}
-
-.wn-marquee-item {
-  font-size: 0.7rem;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: rgba(250, 248, 245, 0.38);
-  white-space: nowrap;
-  display: flex;
-  align-items: center;
-  gap: 3rem;
-}
-
-.wn-marquee-item::after {
-  content: '✦';
   color: var(--wn-accent);
-  font-size: 0.55rem;
 }
 
-@keyframes wn-marquee {
-  from { transform: translateX(0); }
-  to   { transform: translateX(-50%); }
+.wn-serif {
+  font-family: 'DM Serif Display', serif;
 }
 
+/* ───────── Staging banner ───────── */
 .wn-staging-banner {
   background: var(--wn-accent);
   color: var(--wn-white);
@@ -74,4 +45,504 @@
   letter-spacing: 0.2em;
   text-transform: uppercase;
   padding: 0.5rem 1rem;
+  position: relative;
+  z-index: 210;
+}
+
+/* ───────── Nav ───────── */
+.wn-nav {
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.2rem 4rem;
+  background: var(--wn-bg);
+  border-bottom: 1px solid var(--wn-border);
+}
+.wn-logo {
+  font-family: 'DM Serif Display', serif;
+  font-size: 1.3rem;
+  color: var(--wn-dark);
+  text-decoration: none;
+  cursor: pointer;
+}
+.wn-logo span { color: var(--wn-accent); }
+
+.wn-nav-links {
+  display: flex;
+  gap: 2.2rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.wn-nav-links a {
+  color: var(--wn-dark);
+  text-decoration: none;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.55;
+  transition: opacity 0.2s;
+  cursor: pointer;
+}
+.wn-nav-links a:hover { opacity: 1; }
+
+.wn-nav-right {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+}
+
+.wn-lang-toggle {
+  display: flex;
+  border: 1px solid var(--wn-border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.wn-lang-toggle button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--wn-dark);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.7rem;
+  opacity: 0.45;
+  transition: all 0.2s;
+}
+.wn-lang-toggle button.active {
+  background: var(--wn-dark);
+  color: var(--wn-white);
+  opacity: 1;
+}
+
+/* ───────── Buttons ───────── */
+.wn-btn,
+.wn-btn-outline,
+.wn-btn-accent {
+  display: inline-block;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  border-radius: 2px;
+  cursor: pointer;
+  border: none;
+  padding: 0.9rem 2rem;
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+.wn-btn {
+  background: var(--wn-dark);
+  color: var(--wn-white);
+}
+.wn-btn:hover { background: #2e2822; }
+
+.wn-btn-accent {
+  background: var(--wn-accent);
+  color: var(--wn-white);
+  padding: 0.6rem 1.3rem;
+  font-size: 0.75rem;
+}
+.wn-btn-accent:hover { background: var(--wn-accent-dark); }
+
+.wn-btn-outline {
+  background: none;
+  border: 1px solid rgba(24, 21, 18, 0.35);
+  color: var(--wn-dark);
+}
+.wn-btn-outline:hover {
+  background: var(--wn-dark);
+  color: var(--wn-white);
+}
+
+/* ───────── Hero ───────── */
+.wn-hero {
+  position: relative;
+  padding: 7rem 4rem 5rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4rem;
+  align-items: end;
+  min-height: 88vh;
+  overflow: hidden;
+}
+.wn-hero-bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  z-index: 0;
+}
+.wn-hero-bg::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(242, 237, 230, 0.55) 0%, rgba(242, 237, 230, 0.9) 100%);
+}
+.wn-hero-inner {
+  position: relative;
+  z-index: 1;
+  display: contents;
+}
+.wn-tag {
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--wn-accent);
+  margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+.wn-tag::before {
+  content: '';
+  width: 28px;
+  height: 1px;
+  background: var(--wn-accent);
+}
+.wn-hero-h1 {
+  font-family: 'DM Serif Display', serif;
+  font-size: clamp(3rem, 5.5vw, 5.8rem);
+  line-height: 1.02;
+  margin-bottom: 2.5rem;
+  color: var(--wn-dark);
+}
+.wn-hero-right {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 2rem;
+  padding-bottom: 0.5rem;
+}
+.wn-hero-desc {
+  font-size: 1rem;
+  line-height: 1.85;
+  color: var(--wn-mid);
+  max-width: 40ch;
+}
+.wn-hero-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+/* ───────── Stats ───────── */
+.wn-stats {
+  display: flex;
+  border-top: 1px solid var(--wn-border);
+  border-bottom: 1px solid var(--wn-border);
+  background: var(--wn-bg);
+}
+.wn-stat {
+  flex: 1;
+  padding: 2rem 0;
+  text-align: center;
+  border-right: 1px solid var(--wn-border);
+}
+.wn-stat:last-child { border-right: none; }
+.wn-stat-n {
+  font-family: 'DM Serif Display', serif;
+  font-size: 2.6rem;
+  line-height: 1;
+}
+.wn-stat-l {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--wn-mid);
+  margin-top: 0.3rem;
+}
+
+/* ───────── Marquee ───────── */
+.wn-marquee-wrap {
+  overflow: hidden;
+  padding: 0.9rem 0;
+  background: var(--wn-dark);
+}
+.wn-marquee-track {
+  display: flex;
+  gap: 3rem;
+  animation: wn-marquee 22s linear infinite;
+  width: max-content;
+}
+.wn-marquee-item {
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(250, 248, 245, 0.4);
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 3rem;
+}
+.wn-marquee-item::after {
+  content: '✦';
+  color: var(--wn-accent);
+  font-size: 0.55rem;
+}
+@keyframes wn-marquee {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+
+/* ───────── Services strip ───────── */
+.wn-services {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--wn-border);
+}
+.wn-service {
+  background: var(--wn-bg);
+  padding: 2.8rem 2rem;
+  transition: background 0.25s;
+}
+.wn-service:hover { background: var(--wn-white); }
+.wn-service-num {
+  font-family: 'DM Serif Display', serif;
+  font-size: 1.1rem;
+  color: var(--wn-accent);
+  margin-bottom: 1rem;
+}
+.wn-service-name {
+  font-family: 'DM Serif Display', serif;
+  font-size: 1.22rem;
+  margin-bottom: 0.8rem;
+}
+.wn-service-desc {
+  font-size: 0.85rem;
+  line-height: 1.78;
+  color: var(--wn-mid);
+}
+
+/* ───────── Featured ───────── */
+.wn-featured { padding: 5rem 4rem; }
+.wn-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 3rem;
+  gap: 2rem;
+}
+.wn-section-title {
+  font-family: 'DM Serif Display', serif;
+  font-size: clamp(1.8rem, 3vw, 2.8rem);
+  line-height: 1.15;
+  margin: 0;
+}
+.wn-see-all {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--wn-mid);
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--wn-border);
+  padding-bottom: 2px;
+  cursor: pointer;
+  font-family: 'DM Sans', sans-serif;
+  transition: color 0.2s, border-color 0.2s;
+}
+.wn-see-all:hover {
+  color: var(--wn-accent);
+  border-bottom-color: var(--wn-accent);
+}
+.wn-work-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+.wn-work-card {
+  background: var(--wn-light);
+  border-radius: 4px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.3s;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+}
+.wn-work-card:hover { transform: translateY(-5px); }
+.wn-work-img {
+  height: 220px;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--wn-light);
+}
+.wn-work-info { padding: 1.4rem 1.5rem; }
+.wn-work-tag {
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--wn-accent);
+  margin-bottom: 0.5rem;
+}
+.wn-work-title {
+  font-family: 'DM Serif Display', serif;
+  font-size: 1.15rem;
+  margin-bottom: 0.4rem;
+}
+.wn-work-meta {
+  font-size: 0.78rem;
+  color: var(--wn-mid);
+}
+
+/* ───────── Testimonials ───────── */
+.wn-testimonials {
+  padding: 5rem 4rem;
+  background: var(--wn-dark);
+  color: var(--wn-white);
+}
+.wn-testimonials .wn-section-title { color: var(--wn-white); }
+.wn-testi-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  margin-top: 3rem;
+}
+.wn-testi-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  padding: 2rem;
+}
+.wn-testi-stars {
+  color: var(--wn-accent);
+  margin-bottom: 1rem;
+  letter-spacing: 0.15em;
+  font-size: 0.85rem;
+}
+.wn-testi-quote {
+  font-size: 0.9rem;
+  line-height: 1.82;
+  color: rgba(250, 248, 245, 0.65);
+  margin-bottom: 1.5rem;
+  font-style: italic;
+}
+.wn-testi-author { display: flex; align-items: center; gap: 0.8rem; }
+.wn-testi-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--wn-accent);
+  color: var(--wn-white);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+.wn-testi-name { font-size: 0.85rem; color: var(--wn-white); }
+.wn-testi-role { font-size: 0.72rem; color: rgba(250, 248, 245, 0.4); }
+
+/* ───────── CTA ───────── */
+.wn-cta {
+  padding: 4.5rem 4rem;
+  text-align: center;
+  border-top: 1px solid var(--wn-border);
+}
+.wn-cta h2 {
+  font-family: 'DM Serif Display', serif;
+  font-size: clamp(1.8rem, 3.5vw, 3rem);
+  margin-bottom: 1.5rem;
+}
+
+/* ───────── Footer ───────── */
+.wn-footer {
+  background: var(--wn-dark);
+  color: var(--wn-white);
+  padding: 4rem 4rem 0;
+}
+.wn-footer-top {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 3rem;
+  padding-bottom: 3rem;
+}
+.wn-footer-logo {
+  font-family: 'DM Serif Display', serif;
+  font-size: 1.3rem;
+  margin-bottom: 0.8rem;
+}
+.wn-footer-logo span { color: var(--wn-accent); }
+.wn-footer-tag {
+  font-size: 0.82rem;
+  line-height: 1.8;
+  color: rgba(250, 248, 245, 0.4);
+  max-width: 24ch;
+}
+.wn-footer-col-title {
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(250, 248, 245, 0.32);
+  margin-bottom: 1rem;
+}
+.wn-footer-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.wn-footer-links a {
+  color: rgba(250, 248, 245, 0.55);
+  text-decoration: none;
+  font-size: 0.82rem;
+  transition: color 0.2s;
+}
+.wn-footer-links a:hover { color: var(--wn-white); }
+.wn-footer-bottom {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.5rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.wn-footer-copy { font-size: 0.72rem; color: rgba(250, 248, 245, 0.3); }
+
+/* ───────── Reveal animation ───────── */
+.wn-theme [data-wn-reveal] {
+  opacity: 0;
+  transform: translateY(22px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+.wn-theme [data-wn-reveal].wn-visible {
+  opacity: 1;
+  transform: none;
+}
+
+/* ───────── Responsive ───────── */
+@media (max-width: 960px) {
+  .wn-nav { padding: 1rem 1.5rem; }
+  .wn-nav-links { display: none; }
+  .wn-hero {
+    grid-template-columns: 1fr;
+    padding: 6rem 1.5rem 4rem;
+    min-height: auto;
+    gap: 2rem;
+  }
+  .wn-services,
+  .wn-work-grid,
+  .wn-testi-grid { grid-template-columns: 1fr; }
+  .wn-featured,
+  .wn-testimonials,
+  .wn-cta { padding-left: 1.5rem; padding-right: 1.5rem; }
+  .wn-footer { padding: 3rem 1.5rem 0; }
+  .wn-footer-top { grid-template-columns: 1fr 1fr; }
+  .wn-footer-bottom { flex-direction: column; gap: 0.8rem; text-align: center; }
+  .wn-section-head { flex-direction: column; align-items: flex-start; }
+}
+@media (max-width: 600px) {
+  .wn-footer-top { grid-template-columns: 1fr; }
+  .wn-stats { flex-wrap: wrap; }
+  .wn-stat { flex: 0 0 50%; border-bottom: 1px solid var(--wn-border); }
 }

--- a/client/src/pages/whats-next/theme.css
+++ b/client/src/pages/whats-next/theme.css
@@ -235,7 +235,6 @@
 /* ───────── Stats ───────── */
 .wn-stats {
   display: flex;
-  border-top: 1px solid var(--wn-border);
   border-bottom: 1px solid var(--wn-border);
   background: var(--wn-bg);
 }


### PR DESCRIPTION
## Summary
Introduces `/whats-next` — a staging route where visual and feature changes can land before being promoted to production. First iteration ships a fully Forma-inspired home page.

## What's in it
- Cream palette + DM Serif Display / DM Sans, all scoped under `.wn-theme` so prod CSS is untouched.
- Themed nav (EN/PT toggle, "Back to live site" CTA), full-bleed hero with proper background image, dark animated marquee strip, 4-col services grid, featured tours grid pulling real data via `useTours()`, dark testimonials section via `useTestimonials()`, CTA strip and dark footer.
- Custom themed buttons (`.wn-btn`, `.wn-btn-outline`, `.wn-btn-accent`) replace shadcn buttons inside the staging area.
- Global `NavBar` / `Footer` are hidden on `/whats-next` via a `LayoutShell` in `App.tsx` so the themed chrome isn't double-stacked.
- Hero bg fix: the prod `HeroSection` used `z-index:-1`, which got covered by the `.wn-theme` wrapper background. The new hero uses `z-index:0` + a gradient overlay so the configured banner image actually renders.
- Dropped the placeholder stats strip per design feedback; hero flows straight into the marquee.

## Promotion flow
When a feature graduates, move it out of `pages/whats-next/` to its prod location and drop the `wn-` scope.

## Test plan
- [ ] Visit `/whats-next`, `/en/whats-next`, `/pt/whats-next` — themed page renders, lang toggle switches copy.
- [ ] Hero background image from `/api/settings` shows behind the gradient overlay.
- [ ] Global navbar/footer absent on the staging route.
- [ ] Production home `/` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)