### PR TITLE
feat: apply Forma theme site-wide + add marquee on home

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -13,7 +13,7 @@
     <!-- Google Fonts for English and Portuguese -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/components/Marquee.tsx
+++ b/client/src/components/Marquee.tsx
@@ -1,0 +1,95 @@
+import { useTranslation } from "react-i18next";
+
+const ITEMS_EN = [
+  "Lisbon Tours",
+  "Local Guides",
+  "Alfama",
+  "Belém",
+  "Fado Nights",
+  "Tagus River",
+  "Pastéis de Nata",
+  "Hidden Gems",
+];
+
+const ITEMS_PT = [
+  "Tours em Lisboa",
+  "Guias Locais",
+  "Alfama",
+  "Belém",
+  "Noites de Fado",
+  "Rio Tejo",
+  "Pastéis de Nata",
+  "Tesouros Escondidos",
+];
+
+const ITEMS_RU = [
+  "Туры по Лиссабону",
+  "Местные гиды",
+  "Алфама",
+  "Белен",
+  "Вечера фаду",
+  "Река Тежу",
+  "Паштел-де-ната",
+  "Скрытые жемчужины",
+];
+
+/**
+ * Site-wide marquee strip — animated text band with accent stars.
+ * Styled inline so it doesn't depend on Tailwind config.
+ */
+export default function Marquee() {
+  const { i18n } = useTranslation();
+  const code = (i18n.language || "en").slice(0, 2).toLowerCase();
+  const items =
+    code === "pt" ? ITEMS_PT : code === "ru" ? ITEMS_RU : ITEMS_EN;
+  // Duplicate for the seamless -50% translateX loop.
+  const loop = [...items, ...items];
+
+  return (
+    <>
+      <style>{`
+        @keyframes site-marquee {
+          from { transform: translateX(0); }
+          to   { transform: translateX(-50%); }
+        }
+      `}</style>
+      <div
+        aria-hidden="true"
+        style={{
+          overflow: "hidden",
+          padding: "0.9rem 0",
+          backgroundColor: "#181512",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            gap: "3rem",
+            width: "max-content",
+            animation: "site-marquee 28s linear infinite",
+          }}
+        >
+          {loop.map((label, i) => (
+            <span
+              key={`${label}-${i}`}
+              style={{
+                fontSize: "0.7rem",
+                letterSpacing: "0.2em",
+                textTransform: "uppercase",
+                color: "rgba(250, 248, 245, 0.4)",
+                whiteSpace: "nowrap",
+                display: "flex",
+                alignItems: "center",
+                gap: "3rem",
+                fontFamily: '"DM Sans", sans-serif',
+              }}
+            >
+              {label}
+              <span style={{ color: "#E8522A", fontSize: "0.55rem" }}>✦</span>
+            </span>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/client/src/components/layout/Footer.tsx
+++ b/client/src/components/layout/Footer.tsx
@@ -15,13 +15,18 @@ export default function Footer() {
 
   const { t, i18n } = useTranslation();
   return (
-    <footer className="bg-gray-800 text-white pt-12 pb-6">
+    <footer
+      className="text-white pt-12 pb-6"
+      style={{ backgroundColor: "#181512" }}
+    >
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-8">
           <div>
-            <div className="text-2xl font-display font-bold mb-4 flex items-center">
-              <MapPin className="mr-2" />
-              <span>Lisbonlovesme</span>
+            <div className="text-2xl font-display mb-4 flex items-center">
+              <MapPin className="mr-2 text-primary" />
+              <span>
+                Lisbonlovesme<span className="text-primary">.</span>
+              </span>
             </div>
             <p className="text-white/70 mb-4">
               {t('footer.message')}

--- a/client/src/components/layout/NavBar.tsx
+++ b/client/src/components/layout/NavBar.tsx
@@ -37,14 +37,19 @@ export default function NavBar() {
   }, [isOpen]);
 
   return (
-    <nav ref={navRef} className="bg-white shadow-md fixed w-full z-50">
+    <nav
+      ref={navRef}
+      className="bg-background border-b border-border fixed w-full z-50"
+    >
       <div className="container mx-auto px-4 py-3">
         <div className="flex justify-between items-center">
           <div className="flex items-center">
-            <div className="text-xl sm:text-2xl font-display font-bold text-black">
-              <Link href="/" className="flex items-center text-black">
-                <MapPin className="mr-1 sm:mr-2 h-5 w-5 sm:h-6 sm:w-6" />
-                <span className="truncate brand-logo">Lisbonlovesme</span>
+            <div className="text-xl sm:text-2xl text-foreground">
+              <Link href="/" className="flex items-center text-foreground">
+                <MapPin className="mr-1 sm:mr-2 h-5 w-5 sm:h-6 sm:w-6 text-primary" />
+                <span className="truncate brand-logo">
+                  Lisbonlovesme<span className="text-primary">.</span>
+                </span>
               </Link>
             </div>
           </div>
@@ -101,8 +106,8 @@ function NavLink({ href, children, isActive }: NavLinkProps) {
     <Link
       href={href}
       className={cn(
-        "text-black hover:text-black transition-all font-medium",
-        isActive && "text-black"
+        "text-foreground text-sm uppercase tracking-[0.1em] opacity-60 hover:opacity-100 transition-opacity",
+        isActive && "opacity-100 border-b border-primary pb-0.5"
       )}
     >
       {children}
@@ -120,7 +125,7 @@ function MobileNavLink({ href, children, onClick }: MobileNavLinkProps) {
   return (
     <Link
       href={href}
-      className="block py-2 text-black hover:text-black"
+      className="block py-2 text-foreground text-sm uppercase tracking-[0.1em] opacity-80 hover:opacity-100"
       onClick={onClick}
     >
       {children}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -31,27 +31,37 @@ img {
 }
 
 :root {
-      --background: 0 0% 100%;
+      /* Forma palette
+         bg #F2EDE6 / dark #181512 / accent #E8522A / mid #7A6F67 / light #E2DCD4 / white #FAF8F5 */
+      --background: 36 33% 92%;
 --navbar-height: 56px;
---foreground: 20 14.3% 4.1%;
---muted: 60 4.8% 95.9%;
---muted-foreground: 25 5.3% 44.7%;
---popover: 0 0% 100%;
---popover-foreground: 20 14.3% 4.1%;
---card: 0 0% 100%;
---card-foreground: 20 14.3% 4.1%;
---border: 20 5.9% 90%;
---input: 20 5.9% 90%;
---primary: 207 90% 54%;
---primary-foreground: 211 100% 99%;
---secondary: 60 4.8% 95.9%;
---secondary-foreground: 24 9.8% 10%;
---accent: 60 4.8% 95.9%;
---accent-foreground: 24 9.8% 10%;
---destructive: 0 84.2% 60.2%;
---destructive-foreground: 60 9.1% 97.8%;
---ring: 20 14.3% 4.1%;
---radius: 0.5rem;
+--foreground: 24 14% 9%;
+--muted: 30 19% 90%;
+--muted-foreground: 25 9% 44%;
+--popover: 36 33% 97%;
+--popover-foreground: 24 14% 9%;
+--card: 36 33% 97%;
+--card-foreground: 24 14% 9%;
+--border: 24 14% 88%;
+--input: 24 14% 88%;
+--primary: 13 80% 54%;
+--primary-foreground: 36 33% 97%;
+--secondary: 30 19% 86%;
+--secondary-foreground: 24 14% 9%;
+--accent: 13 80% 54%;
+--accent-foreground: 36 33% 97%;
+--destructive: 0 65% 45%;
+--destructive-foreground: 36 33% 97%;
+--ring: 13 80% 54%;
+--radius: 2px;
+
+/* Brand utility colors */
+--brand-cream: 36 33% 92%;
+--brand-dark: 24 14% 9%;
+--brand-accent: 13 80% 54%;
+--brand-mid: 25 9% 44%;
+--brand-light: 30 19% 86%;
+--brand-white: 36 33% 97%;
   }
   .dark {
       --background: 240 10% 3.9%;
@@ -88,7 +98,8 @@ img {
   /* Language-specific font styling */
   html[lang="en"] body,
   html[lang="pt"] body {
-    @apply font-montserrat;
+    font-family: 'DM Sans', sans-serif;
+    font-weight: 300;
   }
 
   /* Titles and headings for English and Portuguese */
@@ -120,29 +131,18 @@ img {
   html[lang="pt"] .text-4xl,
   html[lang="pt"] .text-5xl,
   html[lang="pt"] .text-6xl {
-    font-family: 'Fraunces', serif !important;
-    font-optical-sizing: auto;
-    font-weight: 700 !important; /* Light weight */
+    font-family: 'DM Serif Display', serif !important;
+    font-weight: 400 !important;
     font-style: normal;
-    
   }
 
   /* Logo/Brand name styling for English and Portuguese */
   html[lang="en"] .brand-logo,
   html[lang="pt"] .brand-logo {
-    font-family: 'Fraunces', serif !important;
-    font-weight: 300 !important; /* Light weight */
+    font-family: 'DM Serif Display', serif !important;
+    font-weight: 400 !important;
     font-style: normal;
-    color: black;
-  }
-
-  /* Additional selectors for titles and large text */
-  html[lang="en"] .font-semibold,
-  html[lang="en"] .font-medium,
-  html[lang="pt"] .font-semibold,
-  html[lang="pt"] .font-medium {
-    font-family: 'Fraunces', serif !important;
-    font-weight: 300 !important;
+    color: hsl(var(--foreground));
   }
 
   /* Keep default fonts for Russian */

--- a/client/src/pages/home/HeroSection.tsx
+++ b/client/src/pages/home/HeroSection.tsx
@@ -13,7 +13,7 @@ export default function HeroSection() {
     "https://images.unsplash.com/photo-1558370781-d6196949e317?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1920&h=800";
 
   return (
-    <section className="pt-24 pb-12 md:pt-24 md:pb-14 lg:pt-28 lg:pb-16 relative">
+    <section className="pt-24 pb-12 md:pt-24 md:pb-14 lg:pt-28 lg:pb-16 relative overflow-hidden">
       {/* Background image */}
       <div
         className="absolute inset-0 h-full w-full"
@@ -21,31 +21,53 @@ export default function HeroSection() {
           backgroundImage: `url('${backgroundImage}')`,
           backgroundSize: "cover",
           backgroundPosition: "center",
-          zIndex: -1,
+          zIndex: 0,
         }}
       />
       {/* Readability overlay */}
       <div
-        className="absolute inset-0 h-full w-full bg-black/50"
-        style={{ zIndex: -1 }}
+        className="absolute inset-0 h-full w-full"
+        style={{
+          zIndex: 0,
+          background:
+            "linear-gradient(180deg, rgba(24,21,18,0.55) 0%, rgba(24,21,18,0.7) 100%)",
+        }}
       />
-      
+
       <div className="container mx-auto px-4 relative z-10">
         <div className="max-w-3xl text-white">
-          <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-display font-bold leading-tight mb-4 drop-shadow-lg">
+          <p
+            className="text-xs sm:text-sm uppercase tracking-[0.2em] mb-4 flex items-center gap-3"
+            style={{ color: "#E8522A" }}
+          >
+            <span
+              className="inline-block h-px w-7"
+              style={{ backgroundColor: "#E8522A" }}
+            />
+            Lisbon · Authentic Tours
+          </p>
+          <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-display leading-[1.05] mb-6 drop-shadow-lg">
             {t('home.welcome')}
           </h1>
-          <p className="text-base sm:text-lg md:text-lg lg:text-xl mb-6 sm:mb-8 drop-shadow">
+          <p className="text-base sm:text-lg md:text-lg lg:text-xl mb-6 sm:mb-8 max-w-xl text-white/85 drop-shadow">
             {t('home.subtitle')}
           </p>
-          <div className="flex flex-wrap gap-4">
+          <div className="flex flex-wrap gap-3">
             <Button
               asChild
               size="lg"
-              variant="secondary"
-              className="font-semibold"
+              className="rounded-sm uppercase tracking-[0.12em] text-xs font-medium px-8"
+              style={{ backgroundColor: "#E8522A", color: "#FAF8F5" }}
             >
               <a href="#tours">{t('home.explore')}</a>
+            </Button>
+            <Button
+              asChild
+              size="lg"
+              variant="outline"
+              className="rounded-sm uppercase tracking-[0.12em] text-xs font-medium px-8 bg-transparent border-white/60 text-white hover:bg-white hover:text-foreground"
+            >
+              <a href="#contact">{t('navigation.main.contact')}</a>
             </Button>
           </div>
         </div>

--- a/client/src/pages/home/index.tsx
+++ b/client/src/pages/home/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import HeroSection from "./HeroSection";
+import Marquee from "@/components/Marquee";
 import FeaturedTours from "./FeaturedTours";
 import AboutUs from "./AboutUs";
 import WhyChooseUs from "./WhyChooseUs";
@@ -27,6 +28,7 @@ export default function HomePage() {
   return (
     <>
       <HeroSection />
+      <Marquee />
       <FeaturedTours />
       <AboutUs />
       <WhyChooseUs />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,9 +6,11 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        'fraunces': ['Fraunces', 'serif'],
-        'montserrat': ['Montserrat', 'sans-serif'],
-        'sans': ['ui-sans-serif', 'system-ui', 'sans-serif'],
+        'fraunces': ['"DM Serif Display"', 'serif'],
+        'montserrat': ['"DM Sans"', 'sans-serif'],
+        'display': ['"DM Serif Display"', 'serif'],
+        'serif': ['"DM Serif Display"', 'serif'],
+        'sans': ['"DM Sans"', 'ui-sans-serif', 'system-ui', 'sans-serif'],
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
Promotes the Forma theme from the `/whats-next` staging area to the production site, and ships the marquee strip on the main home page.

## Changes
- **Global tokens** (`client/src/index.css`): Tailwind tokens swapped to the Forma palette — cream `#F2EDE6` bg, deep brown `#181512` fg, accent orange `#E8522A`, mid `#7A6F67`, light `#E2DCD4`. Cascades through every component that uses `bg-background`, `text-foreground`, `text-primary`, `border-border`, etc.
- **Fonts** (`client/index.html`, `tailwind.config.ts`, `client/src/index.css`): replaced Fraunces / Montserrat with DM Serif Display + DM Sans, including the per-language font overrides.
- **NavBar**: cream background, accent dot on the `Lisbonlovesme.` logo, uppercase tracked nav links with accent underline on the active link.
- **Footer**: deep `#181512` bg, accent dot + accent map pin.
- **HeroSection**: fixes the `z-index:-1` bug that was hiding the configured banner image; adds dark gradient overlay, Forma orange tag-line, larger DM Serif headline, accent CTA + outline secondary CTA.
- **Marquee** (`client/src/components/Marquee.tsx`): new component, mounted on the home page between the hero and Featured Tours. Animated scroll, accent stars, localized for EN/PT/RU.

## Test plan
- [ ] Home `/` renders cream bg, dark hero with overlay + image, marquee strip, themed nav and footer.
- [ ] Marquee text reflects the active language.
- [ ] Nav active-link underline shows in accent orange.
- [ ] Existing pages (Tours, Gallery, Guide, Alfama) inherit the new palette without layout breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)